### PR TITLE
Added a setting so pawns can only be seen at a minimum light level

### DIFF
--- a/Languages/English/Keyed/Preferences.xml
+++ b/Languages/English/Keyed/Preferences.xml
@@ -15,6 +15,6 @@
   <fogFadeSpeedSetting_Disabled>Disabled</fogFadeSpeedSetting_Disabled>
   
   <lightMinimum_title>Minimum light level ({0})</lightMinimum_title>
-  <lightMinimum_desc>The minimum light level to see pawns.</lightMinimum_desc>
+  <lightMinimum_desc>The minimum light level to see pawns. At zero pawns are visible at any light level.</lightMinimum_desc>
   
 </LanguageData>

--- a/Languages/English/Keyed/Preferences.xml
+++ b/Languages/English/Keyed/Preferences.xml
@@ -13,4 +13,8 @@
   <fogFadeSpeedSetting_Medium>Medium</fogFadeSpeedSetting_Medium>
   <fogFadeSpeedSetting_Fast>Fast</fogFadeSpeedSetting_Fast>
   <fogFadeSpeedSetting_Disabled>Disabled</fogFadeSpeedSetting_Disabled>
+  
+  <lightMinimum_title>Minimum light level ({0})</lightMinimum_title>
+  <lightMinimum_desc>The minimum light level to see pawns.</lightMinimum_desc>
+  
 </LanguageData>

--- a/Sources/RimWorldRealFoW/RealFoWModSettings.cs
+++ b/Sources/RimWorldRealFoW/RealFoWModSettings.cs
@@ -24,7 +24,7 @@ namespace RimWorldRealFoW {
 
 		public static FogFadeSpeedEnum fogFadeSpeed = FogFadeSpeedEnum.Medium;
 		public static FogAlpha fogAlpha = FogAlpha.Medium;
-        public static float minimumLightLevel;
+		public static float minimumLightLevel;
 
 		public static void DoSettingsWindowContents(Rect rect) {
 			Listing_Standard list = new Listing_Standard(GameFont.Small);
@@ -69,13 +69,13 @@ namespace RimWorldRealFoW {
 			list.Gap();
 			list.GapLine();
 
-            Rect rectLightLevel = list.GetRect(30f);
-            Widgets.Label(rectLightLevel.LeftHalf(), "lightMinimum_title".Translate(minimumLightLevel.ToStringPercent()));
-            minimumLightLevel = Widgets.HorizontalSlider(rectLightLevel.RightHalf(), minimumLightLevel, 0, 1);
+			Rect rectLightLevel = list.GetRect(30f);
+			Widgets.Label(rectLightLevel.LeftHalf(), "lightMinimum_title".Translate(minimumLightLevel.ToStringPercent()));
+			minimumLightLevel = Widgets.HorizontalSlider(rectLightLevel.RightHalf(), minimumLightLevel, 0, 1);
 
-            Text.Font = GameFont.Tiny;
-            list.Label("lightMinimum_desc".Translate());
-            Text.Font = GameFont.Small;
+			Text.Font = GameFont.Tiny;
+			list.Label("lightMinimum_desc".Translate());
+			Text.Font = GameFont.Small;
 
 			list.End();
 		}

--- a/Sources/RimWorldRealFoW/RealFoWModSettings.cs
+++ b/Sources/RimWorldRealFoW/RealFoWModSettings.cs
@@ -24,6 +24,7 @@ namespace RimWorldRealFoW {
 
 		public static FogFadeSpeedEnum fogFadeSpeed = FogFadeSpeedEnum.Medium;
 		public static FogAlpha fogAlpha = FogAlpha.Medium;
+        public static float minimumLightLevel = 0.1f;
 
 		public static void DoSettingsWindowContents(Rect rect) {
 			Listing_Standard list = new Listing_Standard(GameFont.Small);
@@ -65,6 +66,17 @@ namespace RimWorldRealFoW {
 			list.Label("fogFadeSpeedSetting_desc".Translate());
 			Text.Font = GameFont.Small;
 
+			list.Gap();
+			list.GapLine();
+
+            Rect rectLightLevel = list.GetRect(30f);
+            Widgets.Label(rectLightLevel.LeftHalf(), "lightMinimum_title".Translate(minimumLightLevel.ToStringPercent()));
+            minimumLightLevel = Widgets.HorizontalSlider(rectLightLevel.RightHalf(), minimumLightLevel, 0, 1);
+
+            Text.Font = GameFont.Tiny;
+            list.Label("lightMinimum_desc".Translate());
+            Text.Font = GameFont.Small;
+
 			list.End();
 		}
 
@@ -89,6 +101,7 @@ namespace RimWorldRealFoW {
 
 			Scribe_Values.Look(ref fogFadeSpeed, "fogFadeSpeed", FogFadeSpeedEnum.Medium);
 			Scribe_Values.Look(ref fogAlpha, "fogAlpha", FogAlpha.Medium);
+			Scribe_Values.Look(ref minimumLightLevel, "minimumLightLevel", 0.1f);
 
 			applySettings();
 		}

--- a/Sources/RimWorldRealFoW/RealFoWModSettings.cs
+++ b/Sources/RimWorldRealFoW/RealFoWModSettings.cs
@@ -24,7 +24,7 @@ namespace RimWorldRealFoW {
 
 		public static FogFadeSpeedEnum fogFadeSpeed = FogFadeSpeedEnum.Medium;
 		public static FogAlpha fogAlpha = FogAlpha.Medium;
-        public static float minimumLightLevel = 0.1f;
+        public static float minimumLightLevel;
 
 		public static void DoSettingsWindowContents(Rect rect) {
 			Listing_Standard list = new Listing_Standard(GameFont.Small);
@@ -101,7 +101,7 @@ namespace RimWorldRealFoW {
 
 			Scribe_Values.Look(ref fogFadeSpeed, "fogFadeSpeed", FogFadeSpeedEnum.Medium);
 			Scribe_Values.Look(ref fogAlpha, "fogAlpha", FogAlpha.Medium);
-			Scribe_Values.Look(ref minimumLightLevel, "minimumLightLevel", 0.1f);
+			Scribe_Values.Look(ref minimumLightLevel, "minimumLightLevel");
 
 			applySettings();
 		}

--- a/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
+++ b/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
@@ -156,7 +156,7 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 
         private bool lightEnough(IntVec3 position)
         {
-            return glowGrid.GameGlowAt(position) > 0.1f;
+            return glowGrid.GameGlowAt(position) >= RealFoWModSettings.minimumLightLevel;
         }
 
         private bool hasPartShownToPlayer() {

--- a/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
+++ b/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
@@ -102,10 +102,10 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 			Rot4 newRotation = thing.Rotation;
 			if (thing != null && thing.Spawned && thing.Map != null && newPosition != iv3Invalid && (isOneCell || newRotation != r4Invalid)) {
 				if (map != thing.Map) {
-                    map = thing.Map;
-                    fogGrid = map.fogGrid;
-                    glowGrid = map.glowGrid;
-                    mapCompSeenFog = thing.Map.getMapComponentSeenFog();
+					map = thing.Map;
+					fogGrid = map.fogGrid;
+					glowGrid = map.glowGrid;
+					mapCompSeenFog = thing.Map.getMapComponentSeenFog();
 
 				} else if (mapCompSeenFog == null) {
 					mapCompSeenFog = thing.Map.getMapComponentSeenFog();

--- a/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
+++ b/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
@@ -149,18 +149,18 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 #endif
 		}
 
-        private bool canBeSeen(IntVec3 position, bool checkLight)
-        {
-            return hasPartShownToPlayer() && (!checkLight || lightEnough(position));
-        }
+		private bool canBeSeen(IntVec3 position, bool checkLight)
+		{
+	    		return hasPartShownToPlayer() && (!checkLight || lightEnough(position));
+		}
 
-        private bool lightEnough(IntVec3 position)
-        {
+		private bool lightEnough(IntVec3 position)
+		{
 			if (RealFoWModSettings.minimumLightLevel <= 0) return true;
-            return glowGrid.GameGlowAt(position) >= RealFoWModSettings.minimumLightLevel;
-        }
+			return glowGrid.GameGlowAt(position) >= RealFoWModSettings.minimumLightLevel;
+		}
 
-        private bool hasPartShownToPlayer() {
+		private bool hasPartShownToPlayer() {
 			Faction playerFaction = Faction.OfPlayer;
 			if (isOneCell) {
 				return mapCompSeenFog.isShown(playerFaction, lastPosition.x, lastPosition.z);

--- a/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
+++ b/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
@@ -40,7 +40,7 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 		private bool isSaveable;
 		private bool saveCompressible;
 
-        public override void PostSpawnSetup(bool respawningAfterLoad) {
+		public override void PostSpawnSetup(bool respawningAfterLoad) {
 			base.PostSpawnSetup(respawningAfterLoad);
 
 			setupDone = true;

--- a/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
+++ b/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
@@ -27,6 +27,7 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 
 		private Map map;
 		private FogGrid fogGrid;
+        private GlowGrid glowGrid;
 		private MapComponentSeenFog mapCompSeenFog;
 		
 		private CompHiddenable compHiddenable;
@@ -39,7 +40,7 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 		private bool isSaveable;
 		private bool saveCompressible;
 
-		public override void PostSpawnSetup(bool respawningAfterLoad) {
+        public override void PostSpawnSetup(bool respawningAfterLoad) {
 			base.PostSpawnSetup(respawningAfterLoad);
 
 			setupDone = true;
@@ -101,9 +102,10 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 			Rot4 newRotation = thing.Rotation;
 			if (thing != null && thing.Spawned && thing.Map != null && newPosition != iv3Invalid && (isOneCell || newRotation != r4Invalid)) {
 				if (map != thing.Map) {
-					map = thing.Map;
-					fogGrid = map.fogGrid;
-					mapCompSeenFog = thing.Map.getMapComponentSeenFog();
+                    map = thing.Map;
+                    fogGrid = map.fogGrid;
+                    glowGrid = map.glowGrid;
+                    mapCompSeenFog = thing.Map.getMapComponentSeenFog();
 
 				} else if (mapCompSeenFog == null) {
 					mapCompSeenFog = thing.Map.getMapComponentSeenFog();
@@ -114,7 +116,7 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 				}
 				
 				if (forceCheck || !calculated || newPosition != lastPosition || (!isOneCell && newRotation != lastRotation)) {
-					calculated = true;
+					calculated = !isPawn; // always recalculate pawns
 					lastPosition = newPosition;
 					lastRotation = newRotation;
 
@@ -123,9 +125,9 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 					if (mapCompSeenFog != null && !fogGrid.IsFogged(lastPosition)) {
 						if (isSaveable && !saveCompressible) {
 							if (!belongToPlayer) {
-								if (isPawn && !hasPartShownToPlayer()) {
+								if (isPawn && !canBeSeen(lastPosition, true)) {
 									compHiddenable.hide();
-								} else if (!isPawn && !seenByPlayer && !hasPartShownToPlayer()) {
+								} else if (!isPawn && !seenByPlayer && !canBeSeen(lastPosition, false)) {
 									compHiddenable.hide();
 								} else {
 									seenByPlayer = true;
@@ -135,7 +137,7 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 								seenByPlayer = true;
 								compHiddenable.show();
 							}
-						} else if ((forceUpdate || !seenByPlayer) && hasPartShownToPlayer()) {
+						} else if ((forceUpdate || !seenByPlayer) && canBeSeen(lastPosition, false)) {
 							seenByPlayer = true;
 							compHiddenable.show();
 						}
@@ -147,7 +149,17 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 #endif
 		}
 
-		private bool hasPartShownToPlayer() {
+        private bool canBeSeen(IntVec3 position, bool checkLight)
+        {
+            return hasPartShownToPlayer() && (!checkLight || lightEnough(position));
+        }
+
+        private bool lightEnough(IntVec3 position)
+        {
+            return glowGrid.GameGlowAt(position) > 0.1f;
+        }
+
+        private bool hasPartShownToPlayer() {
 			Faction playerFaction = Faction.OfPlayer;
 			if (isOneCell) {
 				return mapCompSeenFog.isShown(playerFaction, lastPosition.x, lastPosition.z);

--- a/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
+++ b/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
@@ -156,6 +156,7 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 
         private bool lightEnough(IntVec3 position)
         {
+            if (RealFoWModSettings.minimumLightLevel <= 0) return true;
             return glowGrid.GameGlowAt(position) >= RealFoWModSettings.minimumLightLevel;
         }
 

--- a/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
+++ b/Sources/RimWorldRealFoW/ThingComps/ThingSubComps/CompHideFromPlayer.cs
@@ -27,7 +27,7 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 
 		private Map map;
 		private FogGrid fogGrid;
-        private GlowGrid glowGrid;
+		private GlowGrid glowGrid;
 		private MapComponentSeenFog mapCompSeenFog;
 		
 		private CompHiddenable compHiddenable;
@@ -156,7 +156,7 @@ namespace RimWorldRealFoW.ThingComps.ThingSubComps {
 
         private bool lightEnough(IntVec3 position)
         {
-            if (RealFoWModSettings.minimumLightLevel <= 0) return true;
+			if (RealFoWModSettings.minimumLightLevel <= 0) return true;
             return glowGrid.GameGlowAt(position) >= RealFoWModSettings.minimumLightLevel;
         }
 


### PR DESCRIPTION
This was a request by one of your users. If the setting is left at 0, nothing changes. Otherwise, the light level has to be at least that amount, before pawns can be seen.

I did add that pawns always get recalculated. The impact of that should be neglectable.